### PR TITLE
[FEAT] 계정 삭제 기능 구현

### DIFF
--- a/src/app/api/login/oauth/kakao/route.ts
+++ b/src/app/api/login/oauth/kakao/route.ts
@@ -2,9 +2,14 @@ import { NextResponse } from 'next/server';
 import { KakaoAccessTokenResponse } from '@/types/login';
 
 export async function POST(request: Request) {
-  const { code } = await request.json();
+  const { code, action } = await request.json();
 
   const clientId = process.env.KAKAO_OAUTH_REST_API_KEY;
+
+  const redirectUri =
+    action === 'login'
+      ? 'http://localhost:3000/login/verify?type=KAKAO'
+      : 'http://localhost:3000/delete?type=KAKAO';
 
   const res = await fetch(`https://kauth.kakao.com/oauth/token`, {
     method: 'POST',
@@ -15,7 +20,7 @@ export async function POST(request: Request) {
       grant_type: 'authorization_code',
       client_id: clientId!,
       code: code!,
-      redirect_uri: 'http://localhost:3000/login/verify?type=KAKAO',
+      redirect_uri: redirectUri,
     }),
   });
   if (!res.ok) {

--- a/src/app/delete/DeleteContent.tsx
+++ b/src/app/delete/DeleteContent.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { usePostKakaoAccessToken } from '@/hooks/query/auth/oauth/usePostKakaoAccessToken';
+
+export default function DeleteContent() {
+  const { mutate: postKakaoAccessToken } = usePostKakaoAccessToken({
+    action: 'delete',
+  });
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
+
+  useEffect(() => {
+    if (code) {
+      postKakaoAccessToken(code);
+    }
+  }, [code, postKakaoAccessToken]);
+
+  return null;
+}

--- a/src/app/delete/page.tsx
+++ b/src/app/delete/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import HeaderLayout from '@/components/layout/header-layout';
+import { Button } from '@/components/ui/button';
+import { usePostKakaoAccessToken } from '@/hooks/query/auth/oauth/usePostKakaoAccessToken';
+
+export default function Page() {
+  const { mutate: postKakaoAccessToken } = usePostKakaoAccessToken({
+    action: 'delete',
+  });
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
+
+  useEffect(() => {
+    if (code) {
+      postKakaoAccessToken(code);
+    }
+  }, [code]);
+
+  const handleDeleteOAuthAccount = () => {
+    window.location.href = process.env.NEXT_PUBLIC_KAKAO_OAUTH_DELETE!;
+  };
+
+  return (
+    <HeaderLayout title="계정삭제" previousPage="/login">
+      <div className="flex flex-col gap-4 mt-[100px]">
+        <p>계정을 삭제하시겠습니까?</p>
+        <Button onClick={handleDeleteOAuthAccount} variant="gray-outline">
+          삭제
+        </Button>
+      </div>
+    </HeaderLayout>
+  );
+}

--- a/src/app/delete/page.tsx
+++ b/src/app/delete/page.tsx
@@ -1,24 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
 import HeaderLayout from '@/components/layout/header-layout';
 import { Button } from '@/components/ui/button';
-import { usePostKakaoAccessToken } from '@/hooks/query/auth/oauth/usePostKakaoAccessToken';
+import DeleteContent from './DeleteContent';
 
 export default function Page() {
-  const { mutate: postKakaoAccessToken } = usePostKakaoAccessToken({
-    action: 'delete',
-  });
-  const searchParams = useSearchParams();
-  const code = searchParams.get('code');
-
-  useEffect(() => {
-    if (code) {
-      postKakaoAccessToken(code);
-    }
-  }, [code]);
-
   const handleDeleteOAuthAccount = () => {
     window.location.href = process.env.NEXT_PUBLIC_KAKAO_OAUTH_DELETE!;
   };
@@ -30,6 +17,9 @@ export default function Page() {
         <Button onClick={handleDeleteOAuthAccount} variant="gray-outline">
           삭제
         </Button>
+        <Suspense fallback={<div>로딩중...</div>}>
+          <DeleteContent />
+        </Suspense>
       </div>
     </HeaderLayout>
   );

--- a/src/hooks/api/user.ts
+++ b/src/hooks/api/user.ts
@@ -2,6 +2,7 @@ import {
   KakaoAccessTokenResponse,
   LoginInfo,
   LoginResponse,
+  DeleteOAuthAccountRequest,
 } from '@/types/login';
 import {
   OAuthLoginRequest,
@@ -100,8 +101,11 @@ export const User = {
     const response = await API.post(`${WIP_API_BASE_URL}/verify/social`, data);
     return response.data;
   },
-  async postKakaoAccessToken(data: { code: string }) {
-    const response = await fetch('/api/login/oauth', {
+  async postKakaoAccessToken(data: {
+    code: string;
+    action: 'login' | 'delete';
+  }) {
+    const response = await fetch('/api/login/oauth/kakao', {
       method: 'POST',
       body: JSON.stringify(data),
     });
@@ -110,6 +114,13 @@ export const User = {
   },
   async getAccountInfo(): Promise<AccountInfo> {
     const response = await API.post(`${WIP_API_BASE_URL}/user/me`);
+    return response.data;
+  },
+  async deleteOAuthAccount(data: DeleteOAuthAccountRequest) {
+    const response = await API.delete(`${WIP_API_BASE_URL}/auth/withdraw`, {
+      data,
+    });
+
     return response.data;
   },
 };

--- a/src/hooks/query/auth/oauth/useDeleteOAuthAccount.ts
+++ b/src/hooks/query/auth/oauth/useDeleteOAuthAccount.ts
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+import { User } from '@/hooks/api/user';
+import { DeleteOAuthAccountRequest } from '@/types/login';
+
+export const useDeleteOAuthAccount = () => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (data: DeleteOAuthAccountRequest) =>
+      User.deleteOAuthAccount(data),
+    onSuccess: () => {
+      alert('탈퇴 성공');
+      router.push('/login');
+    },
+    onError: () => {
+      alert('탈퇴 실패');
+      router.push('/delete');
+    },
+  });
+};

--- a/src/hooks/query/auth/oauth/usePostKakaoAccessToken.ts
+++ b/src/hooks/query/auth/oauth/usePostKakaoAccessToken.ts
@@ -1,14 +1,31 @@
 import { useMutation } from '@tanstack/react-query';
 import { useSignUpStore } from '@/app/sign-up/_/sign-up-store';
 import { User } from '@/hooks/api/user';
+import { useDeleteOAuthAccount } from './useDeleteOAuthAccount';
 import { useVerifyAlreadySignedUp } from './useVerifyAlreadySignedUp';
 
-export const usePostKakaoAccessToken = () => {
+export const usePostKakaoAccessToken = (option?: {
+  action: 'login' | 'delete';
+}) => {
   const { updateSignUpInfo } = useSignUpStore();
+  const { mutate: deleteOAuthAccount } = useDeleteOAuthAccount();
   const { mutate: verifyAlreadySignedUp } = useVerifyAlreadySignedUp();
   return useMutation({
-    mutationFn: (code: string) => User.postKakaoAccessToken({ code }),
+    mutationFn: (code: string) =>
+      User.postKakaoAccessToken({ code, action: option?.action ?? 'login' }),
     onSuccess: (data) => {
+      if (option?.action === 'delete') {
+        if (data.access_token) {
+          deleteOAuthAccount({
+            providerType: 'KAKAO',
+            authCode: data.access_token,
+          });
+        } else {
+          alert('카카오 토큰 발급 실패');
+        }
+        return;
+      }
+
       updateSignUpInfo('providerType', 'KAKAO');
       updateSignUpInfo('authCode', data.access_token);
 

--- a/src/hooks/query/user/useGetUserAccountInfo.ts
+++ b/src/hooks/query/user/useGetUserAccountInfo.ts
@@ -18,11 +18,14 @@ export const useGetUserAccountInfo = ({ redirect }: { redirect?: boolean }) => {
         }
 
         // OWNER 계정 & 가게 승인
-        else if (res.data.approved) {
+        else if (res.data.approved === 'APPROVED') {
           router.push('/store');
         }
-        // OWNER 계정 & 가게 미승인
-        else if (res.data.approved === false) {
+        // OWNER 계정 & 가게 승인 대기, 거절
+        else if (
+          res.data.approved === 'WAITING' ||
+          res.data.approved === 'REJECTED'
+        ) {
           router.push('/register/store/pending');
         }
       }

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -29,3 +29,8 @@ export interface KakaoAccessTokenResponse {
   scope: string;
   refresh_token_expires_in: number;
 }
+
+export interface DeleteOAuthAccountRequest {
+  providerType: OAuthProviderType;
+  authCode: string;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -36,6 +36,6 @@ export interface AccountInfo {
     email: string;
     userRole: 'CUSTOMER' | 'OWNER';
     providerType: keyof typeof loginButtonConfig;
-    approved: boolean | null;
+    approved: 'APPROVED' | 'WAITING' | 'REJECTED';
   };
 }


### PR DESCRIPTION
## 📌 Issue
- #41

## 📝 Description
OAuth 서버와 마감벨 서버의 계정을 모두 삭제해야 하므로 계정 삭제 시에도 OAuth 인가 및 인증 과정을 거쳐 토큰을 발급받은 후 삭제 요청을 진행하도록 구현하였습니다.
이를 위해 로그인 및 회원가입을 위해 작성된 `usePostKakaoAccessToken` query hook에 `action` 매개변수를 추가하고, 해당 값을 login 또는 delete로 구분하여 로직을 분기 처리하였습니다.


<br/>
