### PR TITLE
[FEAT] 검색 페이지 구현, 매장 조회 API 변경사항 반영

### DIFF
--- a/src/app/(index)/_components/header/index.tsx
+++ b/src/app/(index)/_components/header/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import SearchInput from '@/components/input/search';
 import { StoreListSortType } from '@/types/store';
 import SortNav from '../sort-nav';
@@ -12,7 +13,9 @@ export default function MainHeader({
   return (
     <HeaderContainer>
       <AddressEnterLink />
-      <SearchInput placeholder="가게의 이름을 검색해보세요!" />
+      <Link href="/search">
+        <SearchInput placeholder="가게의 이름을 검색해보세요!" />
+      </Link>
       <SortNav sortValue={sortValue} />
     </HeaderContainer>
   );

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -1,69 +1,68 @@
 'use client';
 
-import React from 'react';
-import { Pagination } from 'swiper/modules';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Intersection } from '@/components/intersection/intersection';
-import { StoreList } from '@/components/store/list';
-import { useGetUserFavoriteList } from '@/hooks/query/favorite/useGetUserFavoriteList';
-import { useBagHistoryStore } from '@/hooks/stores/useBagHistoryStore';
-import { BagInfoResponse } from '@/types/bag';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import 'swiper/css';
-import 'swiper/css/pagination';
-import './swiper-styles.css';
-import { Favorite } from './content';
+// import React from 'react';
+// import { Pagination } from 'swiper/modules';
+// import { Swiper, SwiperSlide } from 'swiper/react';
+// import { Intersection } from '@/components/intersection/intersection';
+// import { StoreList } from '@/components/store/list';
+// import { useGetUserFavoriteList } from '@/hooks/query/favorite/useGetUserFavoriteList';
+// import { useBagHistoryStore } from '@/hooks/stores/useBagHistoryStore';
+// import { BagInfoResponse } from '@/types/bag';
+// import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+// import 'swiper/css';
+// import 'swiper/css/pagination';
+// import './swiper-styles.css';
+// import { Favorite } from './content';
 
 export default function Page() {
-  const bagListState = useGetUserFavoriteList({ size: 5 });
-  const {
-    list: favoriteList,
-    intersection,
-    isLoading,
-  } = useInfiniteScroll<BagInfoResponse>(bagListState);
-  const { bagHistory } = useBagHistoryStore();
-
-  if (isLoading) return <> </>;
-
-  return (
-    <Swiper
-      className="screen-swiper"
-      pagination={{
-        clickable: true,
-      }}
-      spaceBetween={30}
-      modules={[Pagination]}
-    >
-      <SwiperSlide>
-        <Favorite.SlideContainer>
-          {favoriteList!.length === 0 ? (
-            <Favorite.Empty />
-          ) : (
-            <div>
-              <StoreList.Container>
-                {favoriteList?.map((item) => (
-                  <StoreList.Item key={`favorite-${item.id}`} data={item} />
-                ))}
-              </StoreList.Container>
-              <Intersection ref={intersection} />
-            </div>
-          )}
-        </Favorite.SlideContainer>
-        <Intersection ref={intersection} />
-      </SwiperSlide>
-      <SwiperSlide>
-        <Favorite.SlideContainer>
-          {!bagHistory.length && <Favorite.Empty />}
-          <div>
-            <StoreList.Container>
-              {bagHistory?.map((item) => (
-                <StoreList.Item key={`bag-history-${item.id}`} data={item} />
-              ))}
-            </StoreList.Container>
-            <Intersection ref={intersection} />
-          </div>
-        </Favorite.SlideContainer>
-      </SwiperSlide>
-    </Swiper>
-  );
+  return <p>favorites</p>; // 기존 즐겨찾기 페이지
+  // const bagListState = useGetUserFavoriteList({ size: 5 });
+  // const {
+  //   list: favoriteList,
+  //   intersection,
+  //   isLoading,
+  // } = useInfiniteScroll<BagInfoResponse>(bagListState);
+  // const { bagHistory } = useBagHistoryStore();
+  // if (isLoading) return <> </>;
+  // return (
+  //   <Swiper
+  //     className="screen-swiper"
+  //     pagination={{
+  //       clickable: true,
+  //     }}
+  //     spaceBetween={30}
+  //     modules={[Pagination]}
+  //   >
+  //     <SwiperSlide>
+  //       <Favorite.SlideContainer>
+  //         {favoriteList!.length === 0 ? (
+  //           <Favorite.Empty />
+  //         ) : (
+  //           <div>
+  //             <StoreList.Container>
+  //               {favoriteList?.map((item) => (
+  //                 <StoreList.Item key={`favorite-${item.id}`} data={item} />
+  //               ))}
+  //             </StoreList.Container>
+  //             <Intersection ref={intersection} />
+  //           </div>
+  //         )}
+  //       </Favorite.SlideContainer>
+  //       <Intersection ref={intersection} />
+  //     </SwiperSlide>
+  //     <SwiperSlide>
+  //       <Favorite.SlideContainer>
+  //         {!bagHistory.length && <Favorite.Empty />}
+  //         <div>
+  //           <StoreList.Container>
+  //             {bagHistory?.map((item) => (
+  //               <StoreList.Item key={`bag-history-${item.id}`} data={item} />
+  //             ))}
+  //           </StoreList.Container>
+  //           <Intersection ref={intersection} />
+  //         </div>
+  //       </Favorite.SlideContainer>
+  //     </SwiperSlide>
+  //   </Swiper>
+  // );
 }

--- a/src/app/map/_components/detail-bottom-sheet.tsx
+++ b/src/app/map/_components/detail-bottom-sheet.tsx
@@ -2,16 +2,23 @@ import { useEffect, useState } from 'react';
 import BottomSheet from '@/components/bottom-sheet/index';
 import BackButton from '@/components/button/back-button';
 import { StoreList } from '@/components/store/list';
+import { DEFAULT_COORD } from '../_constant/map';
 import { useMapStore } from '../_stores/useMapStore';
 
-export default function DetailBottomSheet() {
+export default function DetailBottomSheet({ map }: { map: naver.maps.Map }) {
   const [isDetailBottomSheetOpen, setIsDetailBottomSheetOpen] = useState(false);
   const { selectedStore, setSelectedStore, setIsListSheetHidden } =
     useMapStore();
 
+  const resetMapView = () => {
+    const position = new naver.maps.LatLng(DEFAULT_COORD[0], DEFAULT_COORD[1]);
+    map.morph(position, 7);
+  };
+
   const handleBackButtonClick = () => {
     setIsDetailBottomSheetOpen(false);
     setIsListSheetHidden(false);
+    resetMapView();
   };
 
   useEffect(() => {
@@ -39,7 +46,7 @@ export default function DetailBottomSheet() {
             <StoreList.Item
               data={selectedStore}
               onClick={() => {
-                window.open(`/bag/${selectedStore.id}`, '_blank');
+                window.open(`/bag/${selectedStore.storeId}`, '_blank');
               }}
             />
           </StoreList.Container>

--- a/src/app/map/_components/list-bottom-sheet.tsx
+++ b/src/app/map/_components/list-bottom-sheet.tsx
@@ -4,17 +4,21 @@ import { useCallback, useEffect, useState } from 'react';
 import BottomSheet from '@/components/bottom-sheet/index';
 import { Intersection } from '@/components/intersection/intersection';
 import { StoreList } from '@/components/store/list';
-import { useGetBagInfiniteList } from '@/hooks/query/bag/useGetBagInfiniteList';
-import { BagInfoResponse as StoreInfoResponse } from '@/types/bag';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useGetStoreInfiniteList } from '@/hooks/query/user/useGetStoreInfiniteList';
+import { StoreListItemResponse } from '@/types/store';
+import { useSuspenseInfiniteScroll } from '@/hooks/useSuspenseInfiniteScroll';
 import { useMapStore } from '../_stores/useMapStore';
 import ListShowButton from './list-show-button';
 
 export default function ListBottomSheet({ map }: { map: naver.maps.Map }) {
   const [isListSheetOpen, setIsListSheetOpen] = useState(true);
-  const bagListState = useGetBagInfiniteList({ size: 5 });
-  const { list, intersection, isFetched } = useInfiniteScroll(bagListState);
   const [initialSnap, setInitialSnap] = useState(1);
+  const storeListState = useGetStoreInfiniteList({
+    size: 5,
+    sortType: 'DISTANCE_ASC',
+  });
+  const { list, intersection, isSuccess } =
+    useSuspenseInfiniteScroll<StoreListItemResponse>(storeListState);
   const {
     selectedStore,
     setSelectedStore,
@@ -35,8 +39,8 @@ export default function ListBottomSheet({ map }: { map: naver.maps.Map }) {
   }, [selectedStore]);
 
   const handleStoreItemClick = useCallback(
-    (store: StoreInfoResponse) => {
-      const [lat, lng] = [Number(store.latitude), Number(store.longitude)];
+    (store: StoreListItemResponse) => {
+      const [lat, lng] = [33 + Math.random() * 5, 126 + Math.random() * 3]; // TODO: 매장 좌표 추가
       const position = new naver.maps.LatLng(lat - 0.0005, lng);
       map.morph(position, 18);
       setSelectedStore(store);
@@ -48,7 +52,7 @@ export default function ListBottomSheet({ map }: { map: naver.maps.Map }) {
   return (
     <>
       <ListShowButton onClick={handleListShowButtonClick} />
-      {isListSheetOpen && isFetched && (
+      {isListSheetOpen && isSuccess && (
         <BottomSheet
           isOpen={isListSheetOpen}
           setOpen={setIsListSheetOpen}
@@ -63,7 +67,7 @@ export default function ListBottomSheet({ map }: { map: naver.maps.Map }) {
             <StoreList.Container className="pb-[50px]">
               {list!.map((store) => (
                 <StoreList.Item
-                  key={store.id}
+                  key={store.storeId}
                   data={store}
                   onClick={() => {
                     handleStoreItemClick(store);

--- a/src/app/map/_constant/map.ts
+++ b/src/app/map/_constant/map.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_COORD = [36.5, 127.8];

--- a/src/app/map/_stores/useMapStore.tsx
+++ b/src/app/map/_stores/useMapStore.tsx
@@ -1,9 +1,9 @@
 import { create } from 'zustand';
-import { BagInfoResponse as StoreInfoResponse } from '@/types/bag';
+import { StoreListItemResponse } from '@/types/store';
 
 export type MapStateStore = {
-  selectedStore: StoreInfoResponse | undefined;
-  setSelectedStore: (selectedStore: StoreInfoResponse | undefined) => void;
+  selectedStore: StoreListItemResponse | undefined;
+  setSelectedStore: (selectedStore: StoreListItemResponse | undefined) => void;
   isListSheetHidden: boolean;
   setIsListSheetHidden: (isListSheetHidden: boolean) => void;
 };

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,24 +1,25 @@
 'use client';
 
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { useGetBagList as useGetStoreList } from '@/hooks/query/bag/useGetBagList';
-import { BagInfoResponse as StoreInfoResponse } from '@/types/bag';
+import { useGetStoreList } from '@/hooks/query/store/useGetStoreList';
+import { StoreListItemResponse } from '@/types/store';
 import useModal from '@/hooks/useModal';
 import DetailBottomSheet from './_components/detail-bottom-sheet';
 import ListBottomSheet from './_components/list-bottom-sheet';
 import LocationButton from './_components/location-button';
+import { DEFAULT_COORD } from './_constant/map';
 import { useMapStore } from './_stores/useMapStore';
 import { generateMarker, getUserCurrentPosition } from './_utils/map';
 
 export default function Map() {
   const [userLocation, setUserLocation] = useState<[number, number]>();
   const mapRef = useRef<naver.maps.Map | null>(null);
-  const { data: storeList, isFetched: isStoreListFetched } = useGetStoreList({
-    page: 0,
-    size: 100,
-  });
-  const storeListOnMap = storeList?.pages[0];
-  const { setSelectedStore } = useMapStore();
+  const { data: storeListOnMap, isFetched: isStoreListFetched } =
+    useGetStoreList({
+      size: 100,
+      sortType: 'RECENT_DESC',
+    });
+  const { setSelectedStore, setIsListSheetHidden } = useMapStore();
   const [loadedMap, setLoadedMap] = useState<naver.maps.Map | null>(null);
 
   const { open } = useModal();
@@ -47,7 +48,7 @@ export default function Map() {
   }, [userLocation]);
 
   const handleStoreClick = (
-    store: StoreInfoResponse,
+    store: StoreListItemResponse,
     coord: [number, number],
   ) => {
     const [lat, lng] = coord;
@@ -61,8 +62,7 @@ export default function Map() {
   };
 
   const loadMap = () => {
-    const defaultCoord = [36.5, 127.8];
-    const coord = userLocation || defaultCoord;
+    const coord = userLocation || DEFAULT_COORD;
 
     const mapOptions = {
       center: new naver.maps.LatLng(coord[0] - 0.7, coord[1]),
@@ -86,17 +86,19 @@ export default function Map() {
 
     // 매장 위치 마커 표시
     if (storeListOnMap) {
-      storeListOnMap.forEach((store: StoreInfoResponse) => {
-        const [lat, lng] = [Number(store.latitude), Number(store.longitude)];
+      storeListOnMap.forEach((store: StoreListItemResponse) => {
+        // const [lat, lng] = [Number(store.latitude), Number(store.longitude)];
+        const [lat, lng] = [33 + Math.random() * 5, 126 + Math.random() * 3]; // TODO: 매장 좌표 추가
         const marker = generateMarker({
           name: store.storeName,
-          address: store.address,
+          address: '경기도 용인시 수지구 죽전로 77 1층', // TODO: 매장 주소 추가
           lat,
           lng,
           map,
         });
         naver.maps.Event.addListener(marker, 'click', () => {
           handleStoreClick(store, [lat, lng]);
+          setIsListSheetHidden(true);
         });
       });
     }
@@ -123,7 +125,7 @@ export default function Map() {
     <div id="map" className="w-full h-[100dvh]">
       <LocationButton onClick={morphToCurrentPosition} />
       <ListBottomSheet map={loadedMap!} />
-      <DetailBottomSheet />
+      <DetailBottomSheet map={loadedMap!} />
     </div>
   );
 }

--- a/src/app/search/_components/popular-store-list/index.tsx
+++ b/src/app/search/_components/popular-store-list/index.tsx
@@ -3,7 +3,6 @@ import PopularStoreListItem from './list-item';
 
 export default function PopularStoreList() {
   const { data: storeList } = useGetStoreList({
-    page: 0,
     size: 4,
     sortType: 'RATING_DESC',
   });

--- a/src/app/search/_components/popular-store-list/index.tsx
+++ b/src/app/search/_components/popular-store-list/index.tsx
@@ -1,0 +1,18 @@
+import { useGetStoreList } from '@/hooks/query/store/useGetStoreList';
+import PopularStoreListItem from './list-item';
+
+export default function PopularStoreList() {
+  const { data: storeList } = useGetStoreList({
+    page: 0,
+    size: 4,
+    sortType: 'RATING_DESC',
+  });
+
+  return (
+    <ul className="grid grid-cols-2 gap-[10px] gap-y-[16px] ">
+      {storeList?.map((content) => {
+        return <PopularStoreListItem key={content.storeId} content={content} />;
+      })}
+    </ul>
+  );
+}

--- a/src/app/search/_components/popular-store-list/list-item.tsx
+++ b/src/app/search/_components/popular-store-list/list-item.tsx
@@ -1,0 +1,40 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import DefaultThumbnail from '@/assets/images/store/thumbnail.png';
+import { StoreListItemResponse } from '@/types/store';
+import { Store } from '@/components/store';
+
+export default function PopularStoreListItem({
+  content,
+}: {
+  content: StoreListItemResponse;
+}) {
+  return (
+    <Link
+      href={`/bag/${content.storeId}`}
+      className="flex flex-1 flex-col gap-[8px] clickable"
+    >
+      <div className="w-full h-[100px] overflow-hidden rounded-[10px]">
+        <Image
+          src={
+            content ? `https://${content.ImageUrl[0]}` : DefaultThumbnail.src
+          }
+          alt="마감백 판매 가게"
+          width={500}
+          height={500}
+          className="object-cover w-full h-full bg-gray8"
+        />
+      </div>
+      <div className="flex flex-col gap-[2px]">
+        <Store.Title value={content?.storeName} className="text-b2" />
+        <Store.OpenStatus
+          startTime={content.startTime}
+          endTime={content.endTime}
+          isOpenTextVisible
+          textSize="sm"
+        />
+      </div>
+    </Link>
+  );
+}

--- a/src/app/search/_components/recent-keyword-list/index.tsx
+++ b/src/app/search/_components/recent-keyword-list/index.tsx
@@ -1,0 +1,19 @@
+import { useUserHistoryStore } from '@/hooks/stores/useUserHistoryStore';
+import RecentSearchKeywordChip from '../recent-search-keyword-chip';
+
+export default function RecentKeywordList() {
+  const { searchKeywordHistory, deleteSearchKeywordHistory } =
+    useUserHistoryStore();
+
+  return (
+    <ul className="flex flex-wrap gap-[8px] min-h-[84px] h-[84px] overflow-hidden">
+      {searchKeywordHistory.map((value) => (
+        <RecentSearchKeywordChip
+          key={value}
+          value={value}
+          onDelete={() => deleteSearchKeywordHistory(value)}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/app/search/_components/recent-search-keyword-chip.tsx
+++ b/src/app/search/_components/recent-search-keyword-chip.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import CrossIcon from '@/assets/svg/CrossIcon';
+import Chip from '@/components/ui/chip';
+
+export default function RecentSearchKeywordChip({
+  value,
+  onDelete,
+}: {
+  value: string;
+  onDelete: () => void;
+}) {
+  const handleDeleteButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    onDelete();
+  };
+
+  return (
+    <Link href={`/search?keyword=${value}`} className="clickable">
+      <Chip className="flex items-center gap-[2px]">
+        {value}
+        <button
+          type="button"
+          className="ml-[4px] clickable"
+          onClick={handleDeleteButtonClick}
+        >
+          <CrossIcon />
+        </button>
+      </Chip>
+    </Link>
+  );
+}

--- a/src/app/search/_components/search-result-store-list/index.tsx
+++ b/src/app/search/_components/search-result-store-list/index.tsx
@@ -1,0 +1,36 @@
+import { Intersection } from '@/components/intersection/intersection';
+import { StoreList } from '@/components/store/list';
+import { useGetStoreInfiniteList } from '@/hooks/query/user/useGetStoreInfiniteList';
+import { StoreListItemResponse } from '@/types/store';
+import { useSuspenseInfiniteScroll } from '@/hooks/useSuspenseInfiniteScroll';
+
+export default function SearchResultStoreList({
+  keyword,
+}: {
+  keyword: string;
+}) {
+  const StoreInfiniteListState = useGetStoreInfiniteList({
+    size: 1,
+    sortType: 'RECENT_DESC',
+    keyword,
+  });
+  const { list, intersection } =
+    useSuspenseInfiniteScroll<StoreListItemResponse>(StoreInfiniteListState);
+
+  if (list && list.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[100px]">
+        검색 결과가 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <StoreList.Container>
+      {list?.map((store) => (
+        <StoreList.Item key={store.storeId} data={store} />
+      ))}
+      <Intersection ref={intersection} />
+    </StoreList.Container>
+  );
+}

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import SearchInput from '@/components/input/search';
+import { HeaderLayoutGroup } from '@/components/layout/header-layout';
+import PreviousButton from '@/components/layout/header-layout/previous-button';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, [searchInputRef]);
+
+  return (
+    <HeaderLayoutGroup.Layout>
+      <HeaderLayoutGroup.Header className="py-[10px] h-[58px]">
+        <PreviousButton onClick={router.back} width={8} height={14} />
+        <SearchInput
+          ref={searchInputRef}
+          placeholder="마감백 운영 가게를 검색해보세요!"
+          className="bg-gray10 rounded-[10px] ml-[10px]"
+        />
+      </HeaderLayoutGroup.Header>
+      <HeaderLayoutGroup.Main className="pt-[58px]">
+        {children}
+      </HeaderLayoutGroup.Main>
+    </HeaderLayoutGroup.Layout>
+  );
+}

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,32 +1,80 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import { useRouter } from 'next/navigation';
+import { Suspense, useEffect, useRef, useState, useTransition } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import SearchInput from '@/components/input/search';
 import { HeaderLayoutGroup } from '@/components/layout/header-layout';
 import PreviousButton from '@/components/layout/header-layout/previous-button';
+import Loader from '@/components/loader/loader';
+import { useUserHistoryStore } from '@/hooks/stores/useUserHistoryStore';
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+function Content({ children }: { children: React.ReactNode }) {
   const router = useRouter();
+  const { addSearchKeywordHistory } = useUserHistoryStore();
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const searchParams = useSearchParams();
+  const keywordParam = searchParams.get('keyword');
+  const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
-    searchInputRef.current?.focus();
-  }, [searchInputRef]);
+    setSearchKeyword(keywordParam ?? '');
+  }, [keywordParam]);
+
+  useEffect(() => {
+    if (!keywordParam) {
+      searchInputRef.current?.focus();
+    }
+  }, [keywordParam, searchInputRef]);
+
+  const handlePreviousButtonClick = () => {
+    router.back();
+  };
+
+  const handleSearchKeywordEnter = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    const keyword = e.currentTarget.value;
+    addSearchKeywordHistory(keyword);
+    startTransition(() => {
+      router.push(`?keyword=${keyword}`);
+    });
+  };
+
+  const handleSearchKeywordChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setSearchKeyword(e.currentTarget.value);
+  };
 
   return (
     <HeaderLayoutGroup.Layout>
       <HeaderLayoutGroup.Header className="py-[10px] h-[58px]">
-        <PreviousButton onClick={router.back} width={8} height={14} />
+        <PreviousButton
+          onClick={handlePreviousButtonClick}
+          width={8}
+          height={14}
+        />
         <SearchInput
           ref={searchInputRef}
-          placeholder="마감백 운영 가게를 검색해보세요!"
+          placeholder="마감백 판매 가게를 검색해보세요!"
           className="bg-gray10 rounded-[10px] ml-[10px]"
+          onEnter={handleSearchKeywordEnter}
+          onChange={handleSearchKeywordChange}
+          value={searchKeyword}
         />
       </HeaderLayoutGroup.Header>
       <HeaderLayoutGroup.Main className="pt-[58px]">
-        {children}
+        {isPending ? <Loader /> : children}
       </HeaderLayoutGroup.Main>
     </HeaderLayoutGroup.Layout>
+  );
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense>
+      <Content>{children}</Content>
+    </Suspense>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import LabeledField from '@/components/ui/labeled-field';
+import { useUserHistoryStore } from '@/hooks/stores/useUserHistoryStore';
+import RecentSearchKeywordChip from './_components/recent-search-keyword-chip';
+
+function Content() {
+  const { searchKeywordHistory, deleteSearchKeywordHistory } =
+    useUserHistoryStore();
+  const searchParams = useSearchParams();
+  const keyword = searchParams.get('keyword');
+
+  if (keyword) return <div> {keyword} 검색 결과 페이지 입니다.</div>;
+
+  return (
+    <div className="flex flex-col gap-[30px] mt-[10px]">
+      <LabeledField label="최근 검색어">
+        <ul className="flex flex-wrap gap-[8px]">
+          {searchKeywordHistory.map((value) => (
+            <RecentSearchKeywordChip
+              key={value}
+              value={value}
+              onDelete={() => deleteSearchKeywordHistory(value)}
+            />
+          ))}
+        </ul>
+      </LabeledField>
+      <LabeledField label="우리동네 인기 마감백">
+        우리동네 인기 마감백
+      </LabeledField>
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Content />
+    </Suspense>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -3,32 +3,23 @@
 import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import LabeledField from '@/components/ui/labeled-field';
-import { useUserHistoryStore } from '@/hooks/stores/useUserHistoryStore';
-import RecentSearchKeywordChip from './_components/recent-search-keyword-chip';
+import PopularStoreList from './_components/popular-store-list';
+import RecentKeywordList from './_components/recent-keyword-list';
+import SearchResultStoreList from './_components/search-result-store-list';
 
 function Content() {
-  const { searchKeywordHistory, deleteSearchKeywordHistory } =
-    useUserHistoryStore();
   const searchParams = useSearchParams();
   const keyword = searchParams.get('keyword');
 
-  if (keyword) return <div> {keyword} 검색 결과 페이지 입니다.</div>;
+  if (keyword) return <SearchResultStoreList keyword={keyword} />;
 
   return (
     <div className="flex flex-col gap-[30px] mt-[10px]">
       <LabeledField label="최근 검색어">
-        <ul className="flex flex-wrap gap-[8px]">
-          {searchKeywordHistory.map((value) => (
-            <RecentSearchKeywordChip
-              key={value}
-              value={value}
-              onDelete={() => deleteSearchKeywordHistory(value)}
-            />
-          ))}
-        </ul>
+        <RecentKeywordList />
       </LabeledField>
       <LabeledField label="우리동네 인기 마감백">
-        우리동네 인기 마감백
+        <PopularStoreList />
       </LabeledField>
     </div>
   );

--- a/src/components/input/search/index.tsx
+++ b/src/components/input/search/index.tsx
@@ -1,15 +1,30 @@
-'use client';
-
+import { ForwardedRef, forwardRef } from 'react';
 import SearchIcon from '@/assets/svg/SearchIcon';
+import { cn } from '@/lib/utils';
 
-export default function SearchInput({ placeholder }: { placeholder: string }) {
+export default forwardRef(function SearchInput(
+  {
+    placeholder,
+    className,
+  }: {
+    placeholder: string;
+    className?: string;
+  },
+  ref: ForwardedRef<HTMLInputElement | null>,
+) {
   return (
-    <div className="flex items-center flex-1 gap-[9px] py-[10px] px-[15px] rounded-[10px] h-fit bg-white">
+    <div
+      className={cn(
+        'flex items-center flex-1 gap-[9px] py-[10px] px-[15px] rounded-[10px] h-fit bg-white',
+        className,
+      )}
+    >
       <SearchIcon />
       <input
+        ref={ref}
         className="w-full bg-transparent text-[14px] font-medium text-gray4 placeholder:text-gray4"
         placeholder={placeholder}
       />
     </div>
   );
-}
+});

--- a/src/components/input/search/index.tsx
+++ b/src/components/input/search/index.tsx
@@ -1,17 +1,24 @@
+'use client';
+
 import { ForwardedRef, forwardRef } from 'react';
 import SearchIcon from '@/assets/svg/SearchIcon';
 import { cn } from '@/lib/utils';
 
+type SearchInputProps = React.ComponentProps<'input'> & {
+  onEnter?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+};
+
 export default forwardRef(function SearchInput(
-  {
-    placeholder,
-    className,
-  }: {
-    placeholder: string;
-    className?: string;
-  },
+  { className, onEnter, ...props }: SearchInputProps,
   ref: ForwardedRef<HTMLInputElement | null>,
 ) {
+  const handleEnterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) return; // 한글 입력 시 조합 중인 상태에서는 이벤트 처리를 중단하여 이중 입력 방지
+    if (e.key === 'Enter') {
+      onEnter?.(e);
+    }
+  };
+
   return (
     <div
       className={cn(
@@ -23,7 +30,8 @@ export default forwardRef(function SearchInput(
       <input
         ref={ref}
         className="w-full bg-transparent text-[14px] font-medium text-gray4 placeholder:text-gray4"
-        placeholder={placeholder}
+        onKeyDown={handleEnterKeyDown}
+        {...props}
       />
     </div>
   );

--- a/src/components/layout/header-layout/index.tsx
+++ b/src/components/layout/header-layout/index.tsx
@@ -4,6 +4,60 @@ import { cn } from '@/lib/utils';
 import { padding } from '@/styles/constant';
 import PreviousButton from './previous-button';
 
+function Layout({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        padding: `calc(env(safe-area-inset-top) + 10px) ${padding.layoutX} calc(env(safe-area-inset-bottom) + 20px) ${padding.layoutX}`,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Header({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <header
+      className={cn(
+        'fixed h-[48px] w-full px-[20px] py-[10px] bg-white max-w-[450px] left-1/2 -translate-x-1/2 flex items-center top-[env(safe-area-inset-top)]',
+        className,
+      )}
+    >
+      {children}
+    </header>
+  );
+}
+
+function Main({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <main className={cn('pt-[38px]', className)}>{children}</main>;
+}
+
+export const HeaderLayoutGroup = {
+  Layout,
+  Header,
+  Main,
+};
+
 interface HeaderLayoutProps {
   children: ReactNode;
   title: string;
@@ -15,17 +69,10 @@ interface HeaderLayoutProps {
 
 export default function HeaderLayout(props: HeaderLayoutProps) {
   return (
-    <div
-      style={{
-        padding: `calc(env(safe-area-inset-top) + 10px) ${padding.layoutX} calc(env(safe-area-inset-bottom) + 20px) ${padding.layoutX}`,
-        ...props.style,
-      }}
-    >
-      <header className="fixed h-[48px] w-full px-[20px] py-[10px] bg-white max-w-[450px] left-1/2 -translate-x-1/2 flex items-center top-[env(safe-area-inset-top)]">
+    <HeaderLayoutGroup.Layout style={props.style}>
+      <HeaderLayoutGroup.Header>
         {props.previousButtonClickEvent && (
-          <PreviousButton
-            previousButtonClickEvent={props.previousButtonClickEvent}
-          />
+          <PreviousButton onClick={props.previousButtonClickEvent} />
         )}
         {props.previousPage && (
           <Link href={props.previousPage}>
@@ -35,8 +82,10 @@ export default function HeaderLayout(props: HeaderLayoutProps) {
         <strong className="fixed left-1/2 -translate-x-1/2 text-h4 ml-[-5px]">
           {props.title}
         </strong>
-      </header>
-      <main className={cn('pt-[38px]', props.className)}>{props.children}</main>
-    </div>
+      </HeaderLayoutGroup.Header>
+      <HeaderLayoutGroup.Main className={cn('pt-[38px]', props.className)}>
+        {props.children}
+      </HeaderLayoutGroup.Main>
+    </HeaderLayoutGroup.Layout>
   );
 }

--- a/src/components/layout/header-layout/previous-button.tsx
+++ b/src/components/layout/header-layout/previous-button.tsx
@@ -1,17 +1,21 @@
 import ChevronLeftIcon from '@/assets/svg/ChevronLeftIcon';
 
 export default function PreviousButton({
-  previousButtonClickEvent,
+  onClick,
+  width,
+  height,
 }: {
-  previousButtonClickEvent?: () => void;
+  onClick?: () => void;
+  width?: number;
+  height?: number;
 }) {
   return (
     <button
       type="button"
-      onClick={previousButtonClickEvent}
+      onClick={onClick}
       className="cursor-pointer flex items-center"
     >
-      <ChevronLeftIcon />
+      <ChevronLeftIcon width={width} height={height} />
     </button>
   );
 }

--- a/src/components/store/index.tsx
+++ b/src/components/store/index.tsx
@@ -3,14 +3,20 @@ import Link from 'next/link';
 import ChevronRightIcon from '@/assets/svg/ChevronRightIcon';
 import StarIcon from '@/assets/svg/StarIcon';
 import TimeOutlineIcon from '@/assets/svg/TimeOutlineIcon';
+import { cn } from '@/lib/utils';
 import { StoreDetailWithBag } from '@/types/store';
 import { commaizeNumber } from '@/utils/commaizeNumber';
 import { format24HourTime } from '@/utils/format24HourTime';
 import { Skeleton } from '../ui/skeleton';
 
-function Title({ value }: { value?: string }) {
+function Title({ value, className }: { value?: string; className?: string }) {
   return (
-    <div className="text-b1 font-bold">
+    <div
+      className={cn(
+        'text-b1 font-bold whitespace-nowrap overflow-hidden text-ellipsis',
+        className,
+      )}
+    >
       {value || <Skeleton className="w-[100px] h-[24px]" />}
     </div>
   );
@@ -68,6 +74,7 @@ type OpenStatusProps = Pick<
   'saleStatus' | 'startTime' | 'endTime' | 'quantity'
 > & {
   isOpenTextVisible?: boolean;
+  textSize?: 'md' | 'sm';
 };
 
 function OpenStatus({
@@ -76,7 +83,13 @@ function OpenStatus({
   endTime,
   quantity,
   isOpenTextVisible,
+  textSize = 'md',
 }: Partial<OpenStatusProps>) {
+  const textSizeClass = {
+    md: 'text-b2',
+    sm: 'text-b3',
+  };
+
   if (startTime === undefined)
     return <Skeleton className="w-[250px] h-[21px]" />;
 
@@ -86,13 +99,13 @@ function OpenStatus({
   return (
     <div className="flex items-center gap-[10px]">
       {saleStatus !== undefined && isOpenTextVisible && (
-        <span className="text-b2 font-bold">
+        <span className={cn('font-bold', textSizeClass[textSize])}>
           {saleStatus === 'ON' ? '영업중' : '영업종료'}
         </span>
       )}
-      <p className="flex items-center gap-[4px] flex-row tracking-[-0.02em]">
+      <p className="flex items-center gap-[4px] flex-row tracking-[-0.02em] whitespace-nowrap overflow-hidden text-ellipsis">
         <TimeOutlineIcon />
-        <span className="text-b2 ">
+        <span className={cn('text-b2 ', textSizeClass[textSize])}>
           {isOpenTextVisible && '픽업 가능 시간: '} {startTimeString}~
           {endTimeString}
         </span>
@@ -100,7 +113,9 @@ function OpenStatus({
       {quantity && quantity > 0 ? (
         <>
           <hr className="w-[1px] h-[12px] bg-[#E9E9E9]" />
-          <span className="text-b2 font-bold text-[#EF444D]">
+          <span
+            className={cn('font-bold text-[#EF444D]', textSizeClass[textSize])}
+          >
             {quantity}개 남음
           </span>
         </>
@@ -120,7 +135,7 @@ function HorizontalThumbnail({ images }: { images: string[] }) {
           className="w-[33%] h-[70px] rounded-[8px] overflow-hidden"
         >
           <Image
-            src={image}
+            src={`https://${image}`}
             alt="thumbnail"
             width={200}
             height={70}

--- a/src/components/store/list.tsx
+++ b/src/components/store/list.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { BagInfoResponse } from '@/types/bag';
+import { StoreListItemResponse } from '@/types/store';
 import { Store } from '.';
 
 export default function StoreContainer({
@@ -17,13 +17,11 @@ export default function StoreContainer({
   );
 }
 
-export type StoreListItemProps = BagInfoResponse & { storeId?: number };
-
 export function StoreListItem({
   data,
   onClick,
 }: {
-  data: StoreListItemProps;
+  data: StoreListItemResponse;
   onClick?: () => void;
 }) {
   return (
@@ -33,7 +31,7 @@ export function StoreListItem({
       onClick={onClick}
     >
       <Link
-        href={`/bag/${data.id}`}
+        href={`/store/${data.storeId}`}
         className={cn(
           'flex flex-col items-start gap-[8px] w-full',
           onClick && 'pointer-events-none',
@@ -41,16 +39,24 @@ export function StoreListItem({
       >
         <div className="flex flex-col items-start gap-[4px]">
           <Store.Title value={data.storeName} />
-          {/* <Store.OpenStatus
-            isOpen={data.onSale}
-            startAt={data.startAt}
-            endAt={data.endAt}
-            amount={data.amount}
-          /> */}
-          <Store.Address value={data.address} />
+          <Store.OpenStatus
+            saleStatus={data.saleStatus}
+            startTime={data.startTime}
+            endTime={data.endTime}
+            quantity={data.quantity}
+            isOpenTextVisible
+          />
+          <Store.Address value="경기도 용인시 수지구 죽전로 77 1층" />
+          {/* //TODO: 주소 추가 */}
         </div>
         <Store.HorizontalThumbnail
-          images={data.images ?? [data.image!, data.image!, data.image!]}
+          images={
+            data.ImageUrl ?? [
+              data.ImageUrl[0],
+              data.ImageUrl[0],
+              data.ImageUrl[0],
+            ]
+          }
         />
       </Link>
     </button>

--- a/src/components/ui/chip.tsx
+++ b/src/components/ui/chip.tsx
@@ -1,0 +1,33 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const chipVariants = cva(
+  'rounded-full px-[12px] py-[9px] text-b3 bg-white w-fit border-[1px] border-gray7 font-bold text-gray4',
+  {
+    variants: {
+      variant: {
+        default: '',
+        primary: 'border-primary',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export type ChipProps = React.ComponentProps<'div'> &
+  VariantProps<typeof chipVariants>;
+
+export default function Chip({
+  children,
+  className,
+  variant,
+  ...props
+}: ChipProps) {
+  return (
+    <div className={cn(chipVariants({ variant }), className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/hooks/query/store/useGetStoreList.tsx
+++ b/src/hooks/query/store/useGetStoreList.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { Store } from '@/hooks/api/store';
+import { StoreListRequestParams } from '@/types/store';
+
+export const useGetStoreList = ({
+  page,
+  size,
+  sortType,
+}: StoreListRequestParams) =>
+  useQuery({
+    queryFn: () => Store.getInfiniteList({ page, size, sortType }),
+    queryKey: ['store-list', page, size, sortType],
+    gcTime: 0,
+  });

--- a/src/hooks/query/store/useGetStoreList.tsx
+++ b/src/hooks/query/store/useGetStoreList.tsx
@@ -3,12 +3,11 @@ import { Store } from '@/hooks/api/store';
 import { StoreListRequestParams } from '@/types/store';
 
 export const useGetStoreList = ({
-  page,
   size,
   sortType,
-}: StoreListRequestParams) =>
+}: Omit<StoreListRequestParams, 'page'>) =>
   useQuery({
-    queryFn: () => Store.getInfiniteList({ page, size, sortType }),
-    queryKey: ['store-list', page, size, sortType],
+    queryFn: () => Store.getInfiniteList({ page: 0, size, sortType }),
+    queryKey: ['store-list', size, sortType],
     gcTime: 0,
   });

--- a/src/hooks/stores/useUserHistoryStore.ts
+++ b/src/hooks/stores/useUserHistoryStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface UserHistoryStore {
+  searchKeywordHistory: string[];
+  addSearchKeywordHistory: (value: string) => void;
+  deleteSearchKeywordHistory: (value: string) => void;
+}
+
+export const useUserHistoryStore = create<UserHistoryStore>()(
+  persist(
+    (set) => ({
+      searchKeywordHistory: [],
+      addSearchKeywordHistory: (value) =>
+        set((state) => ({
+          searchKeywordHistory: [
+            value,
+            ...state.searchKeywordHistory.filter(
+              (keyword) => keyword !== value,
+            ),
+          ].slice(0, 10),
+        })),
+      deleteSearchKeywordHistory: (value) =>
+        set((state) => ({
+          searchKeywordHistory: state.searchKeywordHistory.filter(
+            (v) => v !== value,
+          ),
+        })),
+    }),
+    {
+      name: 'search-history-storage',
+    },
+  ),
+);

--- a/src/stories/Chip.stories.tsx
+++ b/src/stories/Chip.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import Chip from '@/components/ui/chip';
+
+const meta = {
+  title: 'Text/Chip',
+  component: Chip,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[500px] flex justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'primary'],
+    },
+  },
+  args: {
+    children: '친절한 사장님',
+    variant: 'default' as 'default' | 'primary',
+  },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};


### PR DESCRIPTION
## 📌 Issue
- #47 

## 📝 Summary
- Search Layout을 새로 설계하는 과정에서 컴포넌트 간 재사용성과 확장성을 높이고자 기존 Header Layout 컴포넌트에 Compound Components 패턴을 적용하였습니다. 이를 통해 Header Layout의 구성 요소들을 유연하게 재조합할 수 있었으며, 기존에는 글자만 표시할 수 있던 영역에 뒤로가기 버튼과 검색 input을 자유롭게 배치하는 작업을 진행하였습니다.

  ```tsx
    <HeaderLayoutGroup.Layout>
      <HeaderLayoutGroup.Header className="py-[10px] h-[58px]">
        <PreviousButton
          onClick={handlePreviousButtonClick}
          width={8}
          height={14}
        />
        <SearchInput
          ref={searchInputRef}
          placeholder="마감백 판매 가게를 검색해보세요!"
          className="bg-gray10 rounded-[10px] ml-[10px]"
          onEnter={handleSearchKeywordEnter}
          onChange={handleSearchKeywordChange}
          value={searchKeyword}
        />
      </HeaderLayoutGroup.Header>
      <HeaderLayoutGroup.Main className="pt-[58px]">
        {isPending ? <Loader /> : children}
      </HeaderLayoutGroup.Main>
    </HeaderLayoutGroup.Layout>
  ```
- 사용자 서비스 이용 이력을 관리하는 `UserHistoryStore` 상태 관리 훅을 작성하였습니다.  
- `Chip` 컴포넌트에 대한 Storybook 스토리를 작성하였습니다.  
- 최근 검색 키워드와 인기 매장을 보여주며, 매장 검색 기능을 제공하는 검색 페이지를 구현하였습니다.  
- API 변경사항을 반영하여 매장 리스트 아이템 컴포넌트를 수정하였고, 해당 컴포넌트를 사용하는 favorite 페이지는 임시로 주석 처리하였으며, map 페이지에는 변경사항을 반영하였습니다.

## 🔎 Experience & Learnings
###  검색 결과 로딩 개선 – `useTransition` 도입 과정

검색 기능에서 사용자가 검색어를 입력하고 Enter를 눌렀을 때, 결과 컴포넌트가 바로 보이지 않는 불편함을 발견했습니다. 
쿼리 파라미터(`?keyword=`)가 변경되어야 결과 컴포넌트가 렌더링되어, 이 과정에서 `검색어 입력 (Enter) → URL 변경 → 결과 렌더링` 사이에 짧은 공백이 발생했습니다. 

그래서 처음 생각한 방법은 `setTimeout`을 활용하여 임시 로딩 처리를 구현하는 것이었습니다. `setLoading(true)`를 호출한 뒤, 100ms 후에 `setLoading(false)`를 호출하는 형태로, 항상 100ms 동안 강제로 Loader를 보여주도록 했습니다. 그러나 이 방식에는 다음과 같은 문제가 있었습니다.
- 네트워크 환경이 느린 경우에는 100ms 이후에도 결과가 준비되지 않아 깜빡임이 발생했습니다.  
- 브라우저 캐싱으로 인해 결과가 즉시 렌더링되는 경우에도 매번 100ms의 불필요한 대기가 발생했습니다.

그래서 이 문제를 해결하기 위해 다음과 같은 방법을 생각해봤습니다.
- **Next.js App Router의 `loading.tsx`**  
  해당 기능을 활용하려면 URL 구조를 /search/[keyword] 같은 동적 세그먼트로 변경해야 했으나, 현재는 쿼리 파라미터 방식(?keyword=)으로 검색 페이지 URL을 표시하는 것이 더 적합하다고 판단했습니다.
- **React 18의 `useTransition`**  
  상태 업데이트나 라우터 네비게이션을 낮은 우선순위로 전환하여 진행할 수 있으며, transition이 진행되는 동안 `isPending` 상태를 통해 정확하게 Loader를 제어할 수 있었습니다. 특히 Next.js 13 이상에서는 `router.push()`도 React 상태로 간주되어 transition 안에서 호출할 수 있기 때문에, 기존 URL 구조를 유지하면서도 정확한 로딩 처리가 가능했습니다.

그래서 `useTransition`으로 문제를 해결하기로 결정했습니다.


### 🛠️ 구현 방법

1. 상태 선언
   ```ts
   const [isPending, startTransition] = useTransition();
   ```

2. Enter 입력시 transition 처리
   ```ts
   const handleSearchKeywordEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const keyword = e.currentTarget.value;
     addSearchKeywordHistory(keyword); // 기존 로직 유지
     startTransition(() => {
       router.push(`?keyword=${keyword}`);
     });
   };
   ```

4. 조건부 Loader 렌더링
   ```tsx
   <HeaderLayoutGroup.Main className="pt-[58px]">
     {isPending ? <Loader /> : children}
   </HeaderLayoutGroup.Main>
   ```

## ✨ Result
다음 태스크로 Skeleton UI를 추가하여 로딩 사용자 경험을 개선해보고자 합니다.
![Jun-28-2025 06-25-39](https://github.com/user-attachments/assets/322ace99-0508-412e-b2e4-ba96227e5bb0)

