### PR TITLE
[FEAT] 네이버 OAuth 로그인 연동, 탈퇴 로직 수정

### DIFF
--- a/src/app/api/login/oauth/naver/route.ts
+++ b/src/app/api/login/oauth/naver/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { OAuthAccessTokenResponse } from '@/types/oauth';
+import { NAVER_OAUTH_CLIENT_ID } from '@/constant';
+
+export async function POST(request: Request) {
+  const { code, state } = await request.json();
+  const clientId = NAVER_OAUTH_CLIENT_ID;
+  const res = await fetch(`https://nid.naver.com/oauth2.0/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: clientId!,
+      client_secret: process.env.NAVER_OAUTH_CLIENT_SECRET!,
+      code: code!,
+      state: state!,
+    }),
+  });
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: 'Failed to fetch data from Kakao' },
+      { status: res.status },
+    );
+  }
+  const data = (await res.json()) as OAuthAccessTokenResponse;
+  return NextResponse.json(data);
+}

--- a/src/app/delete/[OAuthProvider]/page.tsx
+++ b/src/app/delete/[OAuthProvider]/page.tsx
@@ -16,12 +16,15 @@ export default function Page({
   params: { OAuthProvider: OAuthProviderType };
 }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
+  const state = searchParams.get('state');
   const { mutate: postOAuthCode } = usePostOAuthCode({
     action: 'delete',
     OAuthProvider: params.OAuthProvider,
+    state,
   });
-  const searchParams = useSearchParams();
-  const code = searchParams.get('code');
+
   const { open } = useModal();
 
   useEffect(() => {

--- a/src/app/login/verify/[OAuthProvider]/page.tsx
+++ b/src/app/login/verify/[OAuthProvider]/page.tsx
@@ -15,9 +15,11 @@ function VerifyContent({
   const searchParams = useSearchParams();
   const { logout } = useAuth();
   const code = searchParams.get('code');
+  const state = searchParams.get('state');
 
   const { mutate: postOAuthCode } = usePostOAuthCode({
     OAuthProvider,
+    state,
   });
 
   useEffect(() => {

--- a/src/app/sign-up/_/sign-up-store.ts
+++ b/src/app/sign-up/_/sign-up-store.ts
@@ -5,6 +5,7 @@ type SignUpState = {
   signUpInfo: SignUpInfo;
   setSignUpInfo: (state: SignUpInfo) => void;
   updateSignUpInfo: (field: keyof SignUpInfo, value: string) => void;
+  resetSignUpInfo: () => void;
 };
 
 export const signUpInfoDefaultValue = {
@@ -21,4 +22,5 @@ export const useSignUpStore = create<SignUpState>((set) => ({
     set((state) => ({
       signUpInfo: { ...state.signUpInfo, [field]: value },
     })),
+  resetSignUpInfo: () => set({ signUpInfo: signUpInfoDefaultValue }),
 }));

--- a/src/hooks/api/user.ts
+++ b/src/hooks/api/user.ts
@@ -109,12 +109,18 @@ export const User = {
     provider: OAuthProviderType;
     code: string;
     action: 'login' | 'delete';
+    state?: string | null;
   }) {
+    const requestData = { ...data };
+    if (requestData.provider !== 'NAVER') {
+      delete requestData.state;
+    }
+
     const response = await fetch(
-      `/api/login/oauth/${data.provider.toLowerCase()}`,
+      `/api/login/oauth/${requestData.provider.toLowerCase()}`,
       {
         method: 'POST',
-        body: JSON.stringify(data),
+        body: JSON.stringify(requestData),
       },
     );
     const res = (await response.json()) as OAuthAccessTokenResponse;

--- a/src/hooks/query/auth/oauth/usePostOAuthCode.tsx
+++ b/src/hooks/query/auth/oauth/usePostOAuthCode.tsx
@@ -14,13 +14,15 @@ import { useVerifyAlreadySignedUp } from './useVerifyAlreadySignedUp';
 export const usePostOAuthCode = ({
   OAuthProvider,
   action = 'login',
+  state,
 }: {
   OAuthProvider: OAuthProviderType;
   action?: 'login' | 'delete';
+  state?: string | null;
 }) => {
   const { signUpInfo, updateSignUpInfo } = useSignUpStore();
   const { mutate: deleteOAuthAccount } = useDeleteOAuthAccount();
-  const { data: isAlreadySignedUp } = useVerifyAlreadySignedUp();
+  const { data: isAlreadySignedUp } = useVerifyAlreadySignedUp({ action });
   const { mutate: postOAuthLogin } = usePostOAuthLogin();
   const { open } = useModal();
   const route = useRouter();
@@ -48,6 +50,10 @@ export const usePostOAuthCode = ({
   };
 
   useEffect(() => {
+    if (action === 'delete') {
+      closeLoading();
+      return;
+    }
     const OAuthLoginRequest = {
       providerType: signUpInfo.providerType,
       authCode: signUpInfo.authCode,
@@ -73,6 +79,7 @@ export const usePostOAuthCode = ({
         provider: OAuthProvider,
         code,
         action,
+        state,
       }),
     onMutate: () => {
       openLoading();

--- a/src/hooks/query/auth/oauth/usePostOAuthLogin.ts
+++ b/src/hooks/query/auth/oauth/usePostOAuthLogin.ts
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
+import { useSignUpStore } from '@/app/sign-up/_/sign-up-store';
 import { User } from '@/hooks/api/user';
 import { useGetUserAccountInfo } from '@/hooks/query/user/useGetUserAccountInfo';
 import useLoadingModal from '@/hooks/useModal/loading';
@@ -22,6 +23,7 @@ export const usePostOAuthLogin = (nextPage?: string) => {
   const { open } = useModal();
   const { setTokenResponse } = useAuth();
   const { closeLoading } = useLoadingModal();
+  const { resetSignUpInfo } = useSignUpStore();
 
   if (isAccountInfoFetched && accountInfo) {
     // OWNER 계정 리다이렉트 로직
@@ -86,6 +88,7 @@ export const usePostOAuthLogin = (nextPage?: string) => {
           }
         }
       }
+      resetSignUpInfo();
     },
     onError: (err: ErrorResponse<LoginErrorCode>) => {
       closeLoading();

--- a/src/hooks/query/auth/oauth/useVerifyAlreadySignedUp.ts
+++ b/src/hooks/query/auth/oauth/useVerifyAlreadySignedUp.ts
@@ -2,16 +2,22 @@ import { useQuery } from '@tanstack/react-query';
 import { useSignUpStore } from '@/app/sign-up/_/sign-up-store';
 import { User } from '@/hooks/api/user';
 
-export const useVerifyAlreadySignedUp = () => {
+export const useVerifyAlreadySignedUp = (options?: {
+  action?: 'login' | 'delete';
+}) => {
   const { signUpInfo } = useSignUpStore();
 
   return useQuery({
-    queryKey: ['verify-already-signed-up', signUpInfo.authCode],
+    queryKey: [
+      'verify-already-signed-up',
+      signUpInfo.authCode,
+      options?.action,
+    ],
     queryFn: () =>
       User.verifyAlreadySignedUp({
         providerType: signUpInfo.providerType,
         authCode: signUpInfo.authCode,
       }),
-    enabled: signUpInfo.authCode.length > 0,
+    enabled: signUpInfo.authCode.length > 0 && options?.action === 'login',
   });
 };

--- a/src/utils/getOAuthLink.ts
+++ b/src/utils/getOAuthLink.ts
@@ -43,6 +43,7 @@ export default function getOAuthLink(
       },
       NAVER: {
         client_id: NAVER_OAUTH_CLIENT_ID!,
+        state: crypto.randomUUID(),
       },
       APPLE: {
         client_id: APPLE_OAUTH_CLIENT_ID!,


### PR DESCRIPTION
## 📌 Issue
- #28


## 📝 Summary
- 네이버 OAuth 로그인을 연동하였습니다.
  - 네이버는 클라이언트가 로그인 인증 URL에 state 값을 함께 전달하면, 로그인 후 설정된 redirect URI로 리다이렉트할 때 해당 state 값과 code 값을 포함하여 전달합니다. 이후 클라이언트는 이 state 값을 이용해 토큰 발급을 요청해야 하며, 네이버는 이 값이 최초 요청한 것과 일치하는지를 검증합니다. 이를 위해 redirect된 페이지에서 useSearchParams를 사용해 URL 파라미터에서 state 값을 추출하고, 토큰 발급 요청 시 함께 전달하도록 구현하였습니다. 또한, 현재 네이버만 state 값을 검증하기 때문에, OAuthLogin 관련 함수에서는 state를 nullable 타입으로 받아 네이버인 경우에만 이 값을 포함하도록 하였습니다. 그 외의 ProviderType(구글, 카카오, 애플)에서는 state 값을 요청에서 제외하는 방식으로 분기 처리를 적용하였습니다.
- OAuth 로그인, 회원가입, 탈퇴 과정에서 공통적으로 사용하는 usePostOAuthCode mutation 쿼리에 대해 개선 작업을 진행하였습니다. `login`과 `action`으로 분기 처리하여 로직을 작성하였지만, 탈퇴 과정에서 의도하지 않게 로그인 로직이 실행되는 문제가 발생했습니다. 이를 해결하기 위해 각 요청의 목적을 구분할 수 있도록 action 타입 (login, delete)을 명시적으로 전달하도록 변경하였습니다.