### PR TITLE
[FEAT] B ProgressBar 도입

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -27,6 +27,7 @@ const RAW_RUNTIME_STATE =
       [null, {\
         "packageLocation": "./",\
         "packageDependencies": [\
+          ["@bprogress/next", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:3.2.12"],\
           ["@chromatic-com/storybook", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:4.0.0"],\
           ["@hookform/resolvers", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:5.1.0"],\
           ["@portone/browser-sdk", "npm:0.0.23"],\
@@ -6937,6 +6938,74 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../.yarn/berry/cache/@bcoe-v8-coverage-npm-0.2.3-9e27b3c57e-10c0.zip/node_modules/@bcoe/v8-coverage/",\
         "packageDependencies": [\
           ["@bcoe/v8-coverage", "npm:0.2.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@bprogress/core", [\
+      ["npm:1.3.4", {\
+        "packageLocation": "../../../.yarn/berry/cache/@bprogress-core-npm-1.3.4-8e4f0149b1-10c0.zip/node_modules/@bprogress/core/",\
+        "packageDependencies": [\
+          ["@bprogress/core", "npm:1.3.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@bprogress/next", [\
+      ["npm:3.2.12", {\
+        "packageLocation": "../../../.yarn/berry/cache/@bprogress-next-npm-3.2.12-dd675dc592-10c0.zip/node_modules/@bprogress/next/",\
+        "packageDependencies": [\
+          ["@bprogress/next", "npm:3.2.12"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:3.2.12", {\
+        "packageLocation": "./.yarn/__virtual__/@bprogress-next-virtual-a2ca9026f0/4/.yarn/berry/cache/@bprogress-next-npm-3.2.12-dd675dc592-10c0.zip/node_modules/@bprogress/next/",\
+        "packageDependencies": [\
+          ["@bprogress/next", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:3.2.12"],\
+          ["@bprogress/core", "npm:1.3.4"],\
+          ["@bprogress/react", "virtual:a2ca9026f010b194a8f4358004c68d4f9f6c20aace254c62153e72ae677887cd1d2738d1bf4ecad1a65025bd20b3b2efedaf13a89de59700193e5479d0c4383b#npm:1.2.7"],\
+          ["@types/next", null],\
+          ["@types/react", "npm:19.0.12"],\
+          ["@types/react-dom", "npm:18.3.0"],\
+          ["next", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:14.2.11"],\
+          ["react", "npm:18.3.1"],\
+          ["react-dom", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:18.3.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/next",\
+          "@types/react-dom",\
+          "@types/react",\
+          "next",\
+          "react-dom",\
+          "react"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@bprogress/react", [\
+      ["npm:1.2.7", {\
+        "packageLocation": "../../../.yarn/berry/cache/@bprogress-react-npm-1.2.7-3d726061eb-10c0.zip/node_modules/@bprogress/react/",\
+        "packageDependencies": [\
+          ["@bprogress/react", "npm:1.2.7"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:a2ca9026f010b194a8f4358004c68d4f9f6c20aace254c62153e72ae677887cd1d2738d1bf4ecad1a65025bd20b3b2efedaf13a89de59700193e5479d0c4383b#npm:1.2.7", {\
+        "packageLocation": "./.yarn/__virtual__/@bprogress-react-virtual-bf9df8033c/4/.yarn/berry/cache/@bprogress-react-npm-1.2.7-3d726061eb-10c0.zip/node_modules/@bprogress/react/",\
+        "packageDependencies": [\
+          ["@bprogress/react", "virtual:a2ca9026f010b194a8f4358004c68d4f9f6c20aace254c62153e72ae677887cd1d2738d1bf4ecad1a65025bd20b3b2efedaf13a89de59700193e5479d0c4383b#npm:1.2.7"],\
+          ["@bprogress/core", "npm:1.3.4"],\
+          ["@types/react", "npm:19.0.12"],\
+          ["@types/react-dom", "npm:18.3.0"],\
+          ["react", "npm:18.3.1"],\
+          ["react-dom", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:18.3.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/react-dom",\
+          "@types/react",\
+          "react-dom",\
+          "react"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21426,6 +21495,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./",\
         "packageDependencies": [\
           ["mgbell", "workspace:."],\
+          ["@bprogress/next", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:3.2.12"],\
           ["@chromatic-com/storybook", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:4.0.0"],\
           ["@hookform/resolvers", "virtual:df45f35603672abaf560d29318c18c9ff472922c73147c03bf281a188f619b26e7d6443351db5b89d9f904211064d5ae2ef6ca5ac9211e2d92ea79f96c45a8f4#npm:5.1.0"],\
           ["@portone/browser-sdk", "npm:0.0.23"],\

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     ]
   },
   "dependencies": {
+    "@bprogress/next": "^3.2.12",
     "@hookform/resolvers": "^5.1.0",
     "@portone/browser-sdk": "^0.0.23",
     "@radix-ui/react-label": "^2.1.7",

--- a/src/app/client-layout.tsx
+++ b/src/app/client-layout.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import Script from 'next/script';
+import ModalProvider from '@/components/modal/modal-provider';
+import Navigation from '@/components/navigation/navigation';
+import {
+  AppProgressProvider as ProgressProvider,
+  useProgress,
+} from '@bprogress/next';
+import MSWProvider from './(index)/msw-provider/msw-provider';
+import Providers from './(index)/query-provider';
+import Container from './(layout)/container';
+
+function RouteChangeProgress() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { start, stop } = useProgress();
+
+  useEffect(() => {
+    start();
+    const timeoutId = setTimeout(() => {
+      stop();
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
+  }, [pathname, searchParams, start, stop]);
+
+  return null;
+}
+
+export default function ClientLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ProgressProvider
+      height="3px"
+      color="#ffda91F1"
+      options={{
+        showSpinner: false,
+        minimum: 0.3,
+        easing: 'ease',
+        speed: 200,
+      }}
+    >
+      <RouteChangeProgress />
+      <Script
+        strategy="afterInteractive"
+        src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID}`}
+      />
+      <Script src="https://cdn.iamport.kr/v1/iamport.js" />
+      <Providers>
+        <ModalProvider>
+          <MSWProvider />
+          <div id="modal-root" />
+          <Container>{children}</Container>
+          <Navigation />
+        </ModalProvider>
+      </Providers>
+    </ProgressProvider>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,6 @@
-import Script from 'next/script';
 import localFont from 'next/font/local';
-import ModalProvider from '@/components/modal/modal-provider';
-import Navigation from '@/components/navigation/navigation';
 import { cn } from '@/lib/utils';
-import MSWProvider from './(index)/msw-provider/msw-provider';
-import Providers from './(index)/query-provider';
-import Container from './(layout)/container';
+import ClientLayout from './client-layout';
 import type { Metadata, Viewport } from 'next';
 import '../styles/index.css';
 import '../styles/global.css';
@@ -48,9 +43,9 @@ export const viewport: Viewport = {
 
 export default function RootLayout({
   children,
-}: Readonly<{
+}: {
   children: React.ReactNode;
-}>) {
+}) {
   return (
     <html lang="ko">
       <head>
@@ -63,19 +58,7 @@ export default function RootLayout({
         />
       </head>
       <body className={cn(pretendard.variable, 'bg-[#f5f6f8]')}>
-        <Script
-          strategy="afterInteractive"
-          src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID}`}
-        />
-        <Script src="https://cdn.iamport.kr/v1/iamport.js" />
-        <Providers>
-          <ModalProvider>
-            <MSWProvider />
-            <div id="modal-root" />
-            <Container>{children}</Container>
-            <Navigation />
-          </ModalProvider>
-        </Providers>
+        <ClientLayout>{children}</ClientLayout>
       </body>
     </html>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,6 +3780,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bprogress/core@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "@bprogress/core@npm:1.3.4"
+  checksum: 10c0/fae88e83375c5d67b31a7186b6e6fad0f1ef59daee7408c9d6fe150ab3e1b368acfebd1b73ef913567c340803dac96841d81acc05268cdb99118431a26e3f258
+  languageName: node
+  linkType: hard
+
+"@bprogress/next@npm:^3.2.12":
+  version: 3.2.12
+  resolution: "@bprogress/next@npm:3.2.12"
+  dependencies:
+    "@bprogress/core": "npm:^1.3.4"
+    "@bprogress/react": "npm:^1.2.7"
+  peerDependencies:
+    next: ">=13.0.0"
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+  checksum: 10c0/8d993202a81125aae9543814d2248ee9e72e395ba570789362dbaaa9f09dd553f21b6a5c510843eb5fcb0eedfd21b0a7499ac0aa8a924a581910fb2531949aec
+  languageName: node
+  linkType: hard
+
+"@bprogress/react@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "@bprogress/react@npm:1.2.7"
+  dependencies:
+    "@bprogress/core": "npm:^1.3.4"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+  checksum: 10c0/f7683197118ab3a7355dfb8d12e4330ffa543ea4262bc8e04a54fb7a1caf0853e77e9a7648dcb2bba6082e0af1cf6adc5adfba80c63d45f953431e7c7a865419
+  languageName: node
+  linkType: hard
+
 "@bundled-es-modules/cookie@npm:^2.0.0":
   version: 2.0.0
   resolution: "@bundled-es-modules/cookie@npm:2.0.0"
@@ -15064,6 +15097,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "mgbell@workspace:."
   dependencies:
+    "@bprogress/next": "npm:^3.2.12"
     "@chromatic-com/storybook": "npm:^4.0.0-0"
     "@hookform/resolvers": "npm:^5.1.0"
     "@portone/browser-sdk": "npm:^0.0.23"


### PR DESCRIPTION
## 📌 Issue
- #84


## 📝 Summary
- B Progress Bar 라이브러리 설치한 후 레이아웃에 적용하였습니다.
- Root Layout(layout.tsx)에서 클라이언트 컴포넌트 로직을 분리하여 client-layout.tsx로 이동하였습니다.
  - metadata 및 viewport 설정을 서버 컴포넌트에서 처리하도록 변경하였습니다.
  - 클라이언트 사이드 기능(프로그래스바, 스크립트, 네비게이션 등)을 별도 컴포넌트로 분리하였습니다.
  - 서버에서 처리되어야 하는 로직(메타데이터, viewport 설정)과 클라이언트 인터랙션(프로그래스바, 네비게이션)을 명확히 구분하였습니다.



## ✨ Result

![Jul-03-2025 02-39-43](https://github.com/user-attachments/assets/fd5570bc-2943-4561-8daa-ee44a97bc9cc)
